### PR TITLE
Test du retour de getFirstname()

### DIFF
--- a/auth.php
+++ b/auth.php
@@ -21,7 +21,9 @@ if(isset($_SESSION["loged"]) && $_SESSION["loged"] == 1) {
 		$MADMIN->_cookies = $_SESSION['cookies'];
 		// Verification que la session soap n'a pas expiré. 
 		try {
-				$MADMIN->getFirstname();
+				if($MADMIN->getFirstname() == "") {
+                    throw new Exception();
+				}
 		} catch (Exception $e) {
 				session_destroy();
 				// On envoie sur le cas


### PR DESCRIPTION
Si l'utilisateur n'est pas loggué, getFirstname() renvoie une chaîne vide, dans ce cas il faut relancer la session
