### PR TITLE
Corriger la redirection infinie à l'enregistrement

### DIFF
--- a/auth.php
+++ b/auth.php
@@ -21,7 +21,7 @@ if(isset($_SESSION["loged"]) && $_SESSION["loged"] == 1) {
 		$MADMIN->_cookies = $_SESSION['cookies'];
 		// Verification que la session soap n'a pas expiré. 
 		try {
-				if($MADMIN->getFirstname() == "") {
+				if($MADMIN->getFirstname() == "" && $_SESSION['registered'] == true) {
                     throw new Exception();
 				}
 		} catch (Exception $e) {


### PR DESCRIPTION
Il ne faut pas rediriger l'utilisateur vers le CAS si son prénom est vide mais qu'il est en phase d'inscription.
