### PR TITLE
Capturer et afficher les erreurs lors d'un blocage/déblocage

### DIFF
--- a/index.php
+++ b/index.php
@@ -71,17 +71,29 @@ $app->get('/', function() use($app) {
 
 // Blocage du compte
 $app->get('/block', function() use ($app) {
-    JsonClientFactory::getInstance()->getClient("MYACCOUNT")->setSelfBlock(array(
-        "blocage" => true
-    ));
+    try {
+        JsonClientFactory::getInstance()->getClient("MYACCOUNT")->setSelfBlock(array(
+            "blocage" => true
+        ));        
+    }
+    catch(\JsonClient\JsonException $e){
+        $app->flash('block_erreur', $e->getMessage());
+        $app->getLog()->error("Block failed: ".$e->getMessage());
+    }
     $app->response()->redirect($app->urlFor('home'));
 });
 
 // Déblocage du compte
 $app->get('/unblock', function() use ($app) {
-    JsonClientFactory::getInstance()->getClient("MYACCOUNT")->setSelfBlock(array(
-        "blocage" => false
-    ));
+    try {
+        JsonClientFactory::getInstance()->getClient("MYACCOUNT")->setSelfBlock(array(
+            "blocage" => false
+        ));        
+    }
+    catch(\JsonClient\JsonException $e){
+        $app->flash('block_erreur', $e->getMessage());
+        $app->getLog()->error("Unblock failed: ".$e->getMessage());
+    }
     $app->response()->redirect($app->urlFor('home'));
 });
 

--- a/templates/main.php
+++ b/templates/main.php
@@ -63,6 +63,9 @@
                     
         </form>
         <h2>Blocage badge <a name="virement" rel="tooltip" data-placement="bottom" data-original-title="En cas de perte ou vol de ton badge, tu peux ici bloquer et débloquer son utilisation pour payutc" class="hidden-phone"><i class="icon-question-sign"></i></a></h2>
+        <?php if(isset($flash['block_erreur'])): ?>
+            <div class="alert alert-error"><?php echo $flash['block_erreur'] ?></div>
+        <?php endif ?>
         <div class="well">
             <p>
                 État du compte : 


### PR DESCRIPTION
Si la carte est déjà bloquée, la méthode pour bloquer envoie une exception, ce qui génère une erreur 500.
L'exception est capturée et le message affiché correctement.
